### PR TITLE
Properly convert bytes to MB or MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In production use the following [answer from stackoverflow](http://stackoverflow
 4. & at the end means: run this command as a background task.
 
 #### License
-BSD3.
+GPL-3.0
 See [LICENSE](https://github.com/nairobilug/nairobi-bot/blob/master/LICENSE) file for complete license.
 
 #### Other/RTFM

--- a/src/Bot/Data/Network.hs
+++ b/src/Bot/Data/Network.hs
@@ -13,6 +13,7 @@ import Data.ByteString.Char8 as Char8
 import qualified Data.String as S
 import Bot.Types
 import Data.Text as T
+import Numeric
 import Network.HTTP.Client (HttpException(..))
 
 -- Use a max 1 MB response
@@ -31,12 +32,15 @@ opts id' query = defaults
   & header (S.fromString "Accept") .~ [(Char8.pack "text/xml")]
   & param (T.pack "input") .~ [query] & param (T.pack "appid") .~ [id']
 
-toMB :: ByteString -> String
-toMB "" = "unknown"
-toMB size =
+convertBytes :: ByteString -> String
+convertBytes "" = "unknown"
+convertBytes size =
   let kb = 1024^2 :: Double
+      mb = 1024^3 :: Double
       size' = read $ Char8.unpack size
-  in (Prelude.take 4 $ show $ size'/kb)
+  in if size' <= kb
+       then (Prelude.take 4 $ showFFloat Nothing (size'/kb) "") ++ " KB"
+       else (Prelude.take 4 $ showFFloat Nothing (size'/mb) "") ++ " MB"
 
 -- Truncates to 1MB
 parseResponseTruncated :: Response LB.ByteString -> BotResponse ByteString

--- a/src/Bot/URL.hs
+++ b/src/Bot/URL.hs
@@ -61,12 +61,12 @@ extractTitle html =
 handleResponse :: BotResponse ByteString -> [T.Text]
 handleResponse BotResponse{..} =
   if isHTML
-     then htmlText (extractTitle body) (toMB contentLength)
-     else anyOther contentType (toMB contentLength)
+     then htmlText (extractTitle body) (convertBytes contentLength)
+     else anyOther contentType (convertBytes contentLength)
   where isHTML = Char8.isInfixOf "text/html" contentType
-        htmlText title s = [T.pack $ printf "Size: [%s MB] Title: [%s]" s title]
-        anyOther typ s = [T.pack $ printf "Content-Type: [%s] Size: [%s MB]"
-                                           (Char8.unpack typ) s]
+        htmlText title s = [T.pack $ printf "Size: [%s] Title: [ %s ]" s (T.strip $ T.pack title)]
+        anyOther typ s   = [T.pack $ printf "Content-Type: [%s] Size: [%s]"
+                                            (Char8.unpack typ) s]
 
 pageDetails :: URL -> IO [T.Text]
 pageDetails url = do


### PR DESCRIPTION
Better URL handling:
 - Fix conversion of bytes to a human friendly type.
 - Strip whitespace around page titles.