### PR TITLE
Handle different encodings for URLs

### DIFF
--- a/src/Bot/URL.hs
+++ b/src/Bot/URL.hs
@@ -41,39 +41,38 @@ urlBot = proc (InMessage _ msg _ _) -> do
       "http://" `L.isInfixOf` str || "https://" `L.isInfixOf` str
 
     getTitle :: Message -> IO [Message]
-    getTitle msg = (fmap . fmap) T.unpack $ urlList $ S.words msg
+    getTitle msg = urlList $ S.words msg
 
-    urlList :: [URL] -> IO [T.Text]
+    urlList :: [URL] -> IO [String]
     urlList []  = return []
-    urlList lst = fmap join $ mapM pageDetails $ L.filter isStringUrl lst
+    urlList lst = mapM pageDetails $ L.filter isStringUrl lst
 
 extractTitle :: ByteString -> String
 extractTitle html =
-  let tagList = parseTags html
+  let tagList = parseTagsOptions parseOptions{optTagPosition = True} html
       title = "title" :: ByteString
       hasHeadTag =
         foldr (||) False  $ Prelude.map (isTagOpenName title) tagList
       titleTag =
-        Char8.unpack $ renderTags $ getTagContent title (const True) tagList
+        Char8.unpack $ renderTagsOptions renderOptions{optEscape = id} $ getTagContent title (const True) tagList
   in if hasHeadTag
         then titleTag
         else "Page title not found."
 
-handleResponse :: BotResponse ByteString -> [T.Text]
+handleResponse :: BotResponse ByteString -> String
 handleResponse BotResponse{..} =
   if isHTML
      then htmlText (T.strip $ T.pack $ extractTitle body)
                    (convertBytes contentLength)
      else anyOther contentType (convertBytes contentLength)
   where isHTML = Char8.isInfixOf "text/html" contentType
-        htmlText title s = [T.pack $ printf "Size: [%s] Title: [%s]" s title]
-        anyOther typ s   = [T.pack $ printf "Content-Type: [%s] Size: [%s]"
-                                            (Char8.unpack typ) s]
+        htmlText title s = printf "Size: [%s] Title: [%s]" s title
+        anyOther typ s   = printf "Content-Type: [%s] Size: [%s]" (Char8.unpack typ) s
 
-pageDetails :: URL -> IO [T.Text]
+pageDetails :: URL -> IO String
 pageDetails url = do
   eitherResponse <- safeGet url
   case eitherResponse of
     Right response -> return $ handleResponse $ parseResponseTruncated response
-    Left  err ->
-     return $ [(T.pack $ "Fetching URL data failed due to " ++ show err)]
+    Left  _        -> return "Page title not found."
+     -- return $ fmap T.unpack  $ [(T.pack $ "Fetching URL data failed due to " ++ show err)]

--- a/src/Bot/URL.hs
+++ b/src/Bot/URL.hs
@@ -68,7 +68,7 @@ handleResponse BotResponse{..} =
      else anyOther contentType (convertBytes contentLength)
   where lowerCaseContentType = T.toLower $ decodeUtf8 contentType
         isHTML = T.isInfixOf "text/html" lowerCaseContentType
-        isUtf8 = Char8.isInfixOf "utf-8" contentType || Char8.isInfixOf "utf8" contentType
+        isUtf8 = T.isInfixOf "utf-8" lowerCaseContentType || T.isInfixOf "utf8" lowerCaseContentType
         htmlText title s = printf "Size: [%s] Title: [%s]" s title
         anyOther typ s   = printf "Content-Type: [%s] Size: [%s]" (Char8.unpack typ) s
 

--- a/src/Bot/URL.hs
+++ b/src/Bot/URL.hs
@@ -16,6 +16,7 @@ import qualified Data.List as L
 import Text.HTML.TagSoup
 import Text.HTML.TagSoup.Match
 import Text.Printf
+import Data.Text.Encoding
 
 
 urlBot :: MonadIO a => RoomBot a
@@ -49,12 +50,12 @@ urlBot = proc (InMessage _ msg _ _) -> do
 
 extractTitle :: ByteString -> String
 extractTitle html =
-  let tagList = parseTagsOptions parseOptions{optTagPosition = True} html
-      title = "title" :: ByteString
+  let tagList = parseTagsOptions parseOptions{optTagPosition = True} $ decodeUtf8 html
+      title = "title" :: T.Text
       hasHeadTag =
         foldr (||) False  $ Prelude.map (isTagOpenName title) tagList
       titleTag =
-        Char8.unpack $ renderTagsOptions renderOptions{optEscape = id} $ getTagContent title (const True) tagList
+        T.unpack $ renderTagsOptions renderOptions{optEscape = id} $ getTagContent title (const True) tagList
   in if hasHeadTag
         then titleTag
         else "Page title not found."

--- a/src/Bot/URL.hs
+++ b/src/Bot/URL.hs
@@ -62,11 +62,13 @@ extractTitle html =
 
 handleResponse :: BotResponse ByteString -> String
 handleResponse BotResponse{..} =
-  if isHTML
+  if isHTML && isUtf8
      then htmlText (T.strip $ T.pack $ extractTitle body)
                    (convertBytes contentLength)
      else anyOther contentType (convertBytes contentLength)
-  where isHTML = Char8.isInfixOf "text/html" contentType
+  where lowerCaseContentType = T.toLower $ decodeUtf8 contentType
+        isHTML = T.isInfixOf "text/html" lowerCaseContentType
+        isUtf8 = Char8.isInfixOf "utf-8" contentType || Char8.isInfixOf "utf8" contentType
         htmlText title s = printf "Size: [%s] Title: [%s]" s title
         anyOther typ s   = printf "Content-Type: [%s] Size: [%s]" (Char8.unpack typ) s
 

--- a/src/Bot/URL.hs
+++ b/src/Bot/URL.hs
@@ -37,7 +37,8 @@ urlBot = proc (InMessage _ msg _ _) -> do
          else Nothing
 
     isStringUrl :: String -> Bool
-    isStringUrl str = "://" `L.isInfixOf` str
+    isStringUrl str =
+      "http://" `L.isInfixOf` str || "https://" `L.isInfixOf` str
 
     getTitle :: Message -> IO [Message]
     getTitle msg = (fmap . fmap) T.unpack $ urlList $ S.words msg

--- a/tests/Bot/URLSpec.hs
+++ b/tests/Bot/URLSpec.hs
@@ -6,10 +6,10 @@ import Test.Hspec
 import Test.QuickCheck
 import Bot.Types
 import Data.ByteString hiding (any, concat)
-import qualified Data.Text as T
 import Data.Time.Clock
 import Control.Auto
 import Control.Auto.Blip.Internal
+import qualified Data.List as L
 
 
 newtype TestBotResponse = TestBotResponse
@@ -34,11 +34,11 @@ instance Arbitrary TestBotResponse where
 
 propHandleResponse :: TestBotResponse  -> Bool
 propHandleResponse resp =
-  let texty = T.unwords $ handleResponse $ getTestBotResponse resp
+  let texty = handleResponse $ getTestBotResponse resp
       contentType' = contentType $ getTestBotResponse resp
   in if (any (== contentType') ["text/html", "text/html; charset=utf-8"])
-        then (T.isInfixOf "Title: " texty) == True
-        else (T.isInfixOf "Content-Type: " texty) == True
+        then (L.isInfixOf "Title: " texty) == True
+        else (L.isInfixOf "Content-Type: " texty) == True
 
 main :: IO ()
 main = hspec spec

--- a/tests/Bot/URLSpec.hs
+++ b/tests/Bot/URLSpec.hs
@@ -36,7 +36,7 @@ propHandleResponse :: TestBotResponse  -> Bool
 propHandleResponse resp =
   let texty = handleResponse $ getTestBotResponse resp
       contentType' = contentType $ getTestBotResponse resp
-  in if (any (== contentType') ["text/html", "text/html; charset=utf-8"])
+  in if (any (== contentType') ["text/html; charset=utf-8"])
         then (L.isInfixOf "Title: " texty) == True
         else (L.isInfixOf "Content-Type: " texty) == True
 
@@ -64,5 +64,5 @@ botTests = do
 urlTests :: Spec
 urlTests = do
   describe "Extracts URL details given a URL" $ do
-    it "Has Title for type html and Content-Type for anything else" $
+    it "Has Title for type utf8 html and Content-Type for anything else" $
       property $ forAll (arbitrary :: Gen TestBotResponse) propHandleResponse


### PR DESCRIPTION
Convert bytestrings to utf8 before trying to parse webpages.